### PR TITLE
fix: prevent browsers from autocomplete on user update email form inputs

### DIFF
--- a/projects/storefrontlib/src/cms-components/myaccount/update-email/update-email-form/update-email-form.component.html
+++ b/projects/storefrontlib/src/cms-components/myaccount/update-email/update-email-form/update-email-form.component.html
@@ -63,7 +63,7 @@
           }}"
           class="form-control"
           [class.is-invalid]="isNotValid('password')"
-          autocomplete="off"
+          autocomplete="new-password"
         />
         <div class="invalid-feedback" *ngIf="isNotValid('password')">
           <span>{{ 'updateEmailForm.pleaseInputPassword' | cxTranslate }}</span>


### PR DESCRIPTION
Preventing browsers from autocompleting logged user saved email data on Update Email view.